### PR TITLE
Feat2/quadtree 2 - Quadtree traversal and region queries

### DIFF
--- a/src/quadtree/src/area.cairo
+++ b/src/quadtree/src/area.cairo
@@ -33,10 +33,7 @@ impl AreaImpl<T, +Add<T>, +Copy<T>, +Drop<T>, +PointTrait<T>> of AreaTrait<T> {
     }
 
     fn new_from_points(top: T, left: T, bottom: T, right: T) -> Area<T> {
-        Area {
-            top_left: Point { x: left, y: top },
-            bottom_right: Point { x: right, y: bottom },
-        }
+        Area { top_left: Point { x: left, y: top }, bottom_right: Point { x: right, y: bottom }, }
     }
 
 
@@ -53,7 +50,7 @@ impl AreaImpl<T, +Add<T>, +Copy<T>, +Drop<T>, +PointTrait<T>> of AreaTrait<T> {
     }
 
     fn top(self: @Area<T>) -> T {
-       *self.top_left.y
+        *self.top_left.y
     }
 
     fn left(self: @Area<T>) -> T {

--- a/src/quadtree/src/area.cairo
+++ b/src/quadtree/src/area.cairo
@@ -10,19 +10,33 @@ struct Area<T> {
 trait AreaTrait<T> {
     /// Creates a new area
     fn new(top_left: Point<T>, width: T, height: T) -> Area<T>;
+    fn new_from_points(top: T, left: T, bottom: T, right: T) -> Area<T>;
     /// Checks if the area contains a point
     fn contains(self: @Area<T>, point: @Point<T>) -> bool;
     /// Checks if the area intersects or contains another area
     fn intersects(self: @Area<T>, other: @Area<T>) -> bool;
+    /// Getters for bouds of the area
+    fn top(self: @Area<T>) -> T;
+    fn left(self: @Area<T>) -> T;
+    fn bottom(self: @Area<T>) -> T;
+    fn right(self: @Area<T>) -> T;
 }
 
-impl AreaTraitImpl<T, +Add<T>, +Copy<T>, +Drop<T>, +PointTrait<T>> of AreaTrait<T> {
+impl AreaImpl<T, +Add<T>, +Copy<T>, +Drop<T>, +PointTrait<T>> of AreaTrait<T> {
     fn new(top_left: Point<T>, width: T, height: T) -> Area<T> {
         Area {
             top_left: top_left,
             bottom_right: Point { x: top_left.x + width, y: top_left.y + height },
         }
     }
+
+    fn new_from_points(top: T, left: T, bottom: T, right: T) -> Area<T> {
+        Area {
+            top_left: Point { x: left, y: top },
+            bottom_right: Point { x: right, y: bottom },
+        }
+    }
+
 
     fn contains(self: @Area<T>, point: @Point<T>) -> bool {
         point.between_x(self.top_left, self.bottom_right)
@@ -34,5 +48,21 @@ impl AreaTraitImpl<T, +Add<T>, +Copy<T>, +Drop<T>, +PointTrait<T>> of AreaTrait<
             && other.top_left.lt_x(self.bottom_right)
             && self.top_left.lt_y(other.bottom_right)
             && other.top_left.lt_y(self.bottom_right)
+    }
+
+    fn top(self: @Area<T>) -> T {
+       *self.top_left.y
+    }
+
+    fn left(self: @Area<T>) -> T {
+        *self.top_left.x
+    }
+
+    fn bottom(self: @Area<T>) -> T {
+        *self.bottom_right.y
+    }
+
+    fn right(self: @Area<T>) -> T {
+        *self.bottom_right.x
     }
 }

--- a/src/quadtree/src/area.cairo
+++ b/src/quadtree/src/area.cairo
@@ -20,6 +20,8 @@ trait AreaTrait<T> {
     fn left(self: @Area<T>) -> T;
     fn bottom(self: @Area<T>) -> T;
     fn right(self: @Area<T>) -> T;
+    fn top_left(self: @Area<T>) -> @Point<T>;
+    fn bottom_right(self: @Area<T>) -> @Point<T>;
 }
 
 impl AreaImpl<T, +Add<T>, +Copy<T>, +Drop<T>, +PointTrait<T>> of AreaTrait<T> {
@@ -64,5 +66,13 @@ impl AreaImpl<T, +Add<T>, +Copy<T>, +Drop<T>, +PointTrait<T>> of AreaTrait<T> {
 
     fn right(self: @Area<T>) -> T {
         *self.bottom_right.x
+    }
+
+    fn top_left(self: @Area<T>) -> @Point<T> {
+        self.top_left
+    }
+
+    fn bottom_right(self: @Area<T>) -> @Point<T> {
+        self.bottom_right
     }
 }

--- a/src/quadtree/src/lib.cairo
+++ b/src/quadtree/src/lib.cairo
@@ -35,5 +35,5 @@ trait QuadtreeTrait<T, P, C> {
     /// Inserts a region into the quadtree.
     fn insert(ref self: Felt252Quadtree<T, P, C>, value: T, path: P, mask: P);
     /// Splits a region into 4 subregions at a given point.
-    fn split(ref self: Felt252Quadtree<T, P, C>, area: @Area<C>, point: Point<C>, path: P);
+    fn split(ref self: Felt252Quadtree<T, P, C>, path: P, point: Point<C>);
 }

--- a/src/quadtree/src/lib.cairo
+++ b/src/quadtree/src/lib.cairo
@@ -3,9 +3,10 @@ mod tests;
 mod area;
 mod point;
 mod quadtree;
+mod node;
 
-use quadtree::{Point, Area, Felt252Quadtree, Felt252QuadtreeNode};
-
+use quadtree::{Point, Area, Felt252Quadtree};
+use node::QuadtreeNode;
 
 //! Quadree implementation.
 //!
@@ -30,8 +31,10 @@ use quadtree::{Point, Area, Felt252Quadtree, Felt252QuadtreeNode};
 trait QuadtreeTrait<T, P, C> {
     /// Creates a new uadtree instance.
     fn new(region: Area<C>) -> Felt252Quadtree<T, P, C>;
-    /// Gets the value at the root of the quadtree.
+    /// Gets values at the a given path.
     fn values(ref self: Felt252Quadtree<T, P, C>, path: P) -> Array<T>;
+    /// Queries the quadtree for the regions that contain a given point.
+    fn query_regions(ref self: Felt252Quadtree<T, P, C>, point: Point<C>) -> Array<T>;
     /// Inserts a region into the quadtree.
     fn insert_point(ref self: Felt252Quadtree<T, P, C>, value: T, point: Point<C>);
     fn insert_region(ref self: Felt252Quadtree<T, P, C>, value: T, region: Area<C>);

--- a/src/quadtree/src/lib.cairo
+++ b/src/quadtree/src/lib.cairo
@@ -33,7 +33,9 @@ trait QuadtreeTrait<T, P, C> {
     /// Gets the value at the root of the quadtree.
     fn values(ref self: Felt252Quadtree<T, P, C>, path: P) -> Array<T>;
     /// Inserts a region into the quadtree.
-    fn insert(ref self: Felt252Quadtree<T, P, C>, value: T, path: P, mask: P);
+    fn insert_point(ref self: Felt252Quadtree<T, P, C>, value: T, point: Point<C>);
+    // fn insert_region(ref self: Felt252Quadtree<T, P, C>, value: T, region: Area<C>);
+    fn insert_at(ref self: Felt252Quadtree<T, P, C>, value: T, path: P);
     /// Splits a region into 4 subregions at a given point.
     fn split(ref self: Felt252Quadtree<T, P, C>, path: P, point: Point<C>);
 }

--- a/src/quadtree/src/lib.cairo
+++ b/src/quadtree/src/lib.cairo
@@ -4,8 +4,7 @@ mod area;
 mod point;
 mod quadtree;
 
-use quadtree::{Felt252Quadtree, Felt252QuadtreeNode};
-use quadtree::Area;
+use quadtree::{Point, Area, Felt252Quadtree, Felt252QuadtreeNode};
 
 
 //! Quadree implementation.
@@ -34,5 +33,7 @@ trait QuadtreeTrait<T, P, C> {
     /// Gets the value at the root of the quadtree.
     fn values(ref self: Felt252Quadtree<T, P, C>, path: P) -> Array<T>;
     /// Inserts a region into the quadtree.
-    fn insert(ref self: Felt252Quadtree<T, P, C>, path: P, value: T);
+    fn insert(ref self: Felt252Quadtree<T, P, C>, value: T, path: P, mask: P);
+    /// Splits a region into 4 subregions at a given point.
+    fn split(ref self: Felt252Quadtree<T, P, C>, area: @Area<C>, point: Point<C>, path: P);
 }

--- a/src/quadtree/src/lib.cairo
+++ b/src/quadtree/src/lib.cairo
@@ -34,7 +34,7 @@ trait QuadtreeTrait<T, P, C> {
     fn values(ref self: Felt252Quadtree<T, P, C>, path: P) -> Array<T>;
     /// Inserts a region into the quadtree.
     fn insert_point(ref self: Felt252Quadtree<T, P, C>, value: T, point: Point<C>);
-    // fn insert_region(ref self: Felt252Quadtree<T, P, C>, value: T, region: Area<C>);
+    fn insert_region(ref self: Felt252Quadtree<T, P, C>, value: T, region: Area<C>);
     fn insert_at(ref self: Felt252Quadtree<T, P, C>, value: T, path: P);
     /// Splits a region into 4 subregions at a given point.
     fn split(ref self: Felt252Quadtree<T, P, C>, path: P, point: Point<C>);

--- a/src/quadtree/src/lib.cairo
+++ b/src/quadtree/src/lib.cairo
@@ -6,7 +6,7 @@ mod quadtree;
 mod node;
 
 use quadtree::{Point, Area, Felt252Quadtree};
-use node::QuadtreeNode;
+use node::{QuadtreeNode, QuadtreeNodeTrait};
 
 //! Quadree implementation.
 //!

--- a/src/quadtree/src/node.cairo
+++ b/src/quadtree/src/node.cairo
@@ -62,14 +62,14 @@ impl QuadtreeNodeImpl<
         match self.is_leaf {
             // compare coordinates with the middle of the region in the greater
             Option::Some(middle) => Option::Some(
-                match point.lt_y(middle) {
-                    true => match point.lt_x(middle) {
-                        true => *self.path * four + one.into(),
-                        false => *self.path * four,
+                match middle.lt_y(point) {
+                    false => match middle.lt_x(point) {
+                        false => *self.path * four + one.into(),
+                        true => *self.path * four,
                     },
-                    false => match point.lt_x(middle) {
-                        true => *self.path * four + bottom.into(),
-                        false => *self.path * four + bottom.into() + one.into()
+                    true => match middle.lt_x(point) {
+                        false => *self.path * four + bottom.into(),
+                        true => *self.path * four + bottom.into() + one.into()
                     },
                 }
             ),
@@ -149,10 +149,10 @@ fn test_node_child_at() {
     assert(node.child_at(@PointTrait::new(0, 4)).unwrap() == 0b110, 'sw corner');
     assert(node.child_at(@PointTrait::new(4, 4)).unwrap() == 0b111, 'se corner');
 
-    assert(node.child_at(@PointTrait::new(2, 0)).unwrap() == 0b100, 'ne over nw');
-    assert(node.child_at(@PointTrait::new(0, 2)).unwrap() == 0b110, 'sw over nw');
-    assert(node.child_at(@PointTrait::new(2, 4)).unwrap() == 0b111, 'se over sw');
-    assert(node.child_at(@PointTrait::new(4, 2)).unwrap() == 0b111, 'se over ne');
+    assert(node.child_at(@PointTrait::new(2, 0)).unwrap() == 0b101, 'nw over ne');
+    assert(node.child_at(@PointTrait::new(0, 2)).unwrap() == 0b101, 'nw over sw');
+    assert(node.child_at(@PointTrait::new(2, 4)).unwrap() == 0b110, 'sw over se');
+    assert(node.child_at(@PointTrait::new(4, 2)).unwrap() == 0b100, 'ne over se');
 }
 
 #[test]

--- a/src/quadtree/src/node.cairo
+++ b/src/quadtree/src/node.cairo
@@ -1,0 +1,70 @@
+use core::zeroable::Zeroable;
+use quadtree::area::{AreaTrait, Area, AreaImpl};
+use quadtree::point::{Point, PointTrait, PointImpl};
+
+/// Each node in the quadtree is a struct with a region, a path, a mask and a list of values.
+#[derive(Drop)]
+struct QuadtreeNode<T, P, C> {
+    /// Values for a given region of the quadtree.
+    values: Span<T>,
+    /// The region of the grometry that this node represents.
+    region: Area<C>,
+    /// The path of the node in the quadtree, the first bit is always a 1 and the
+    /// each 2 bits store a quadrant (ne, nw, se, sw).
+    /// e.g. 0b100 is the top right, 0b101 is the top left quadrant, 
+    /// 0b11111 is the bottom right quadrant of the bottom right.
+    path: P,
+    /// Whether the node is a leaf or not.
+    is_leaf: Option<Point<C>>,
+}
+
+trait QuadtreeNodeTrait<T, P, C> {
+    fn child_at(self: @QuadtreeNode<T, P, C>, point: @Point<C>) -> Option<P>;
+}
+
+impl QuadtreeNodeImpl<
+    T,
+    P,
+    C,
+    +Copy<T>,
+    +Copy<C>,
+    +Copy<P>,
+    +Drop<T>,
+    +Drop<C>,
+    +Drop<P>,
+    +Zeroable<P>, // Root has zero path of type P
+    +Into<P, felt252>, // Dict key is felt252
+    +Into<u8, P>, // Adding nested level
+    +Add<P>, // Nesting the path
+    +Mul<P>, // Nesting the path
+    +Add<C>, // Needed for area
+    +PointTrait<C>, // Present in the area
+> of QuadtreeNodeTrait<T, P, C> {
+    fn child_at(self: @QuadtreeNode<T, P, C>, point: @Point<C>) -> Option<P> {
+        // type interference hack
+        let one: u8 = 1;
+        let bottom = one + one;
+        let four: P = (bottom + bottom).into();
+
+        match self.is_leaf {
+            Option::Some(middle) => Option::Some(
+                {
+                    match point.lt_x(middle) {
+                        true => match point.lt_y(middle) {
+                            true => *self.path * four + one.into(),
+                            false => *self.path * four + bottom.into(),
+                        },
+                        false => match point.lt_y(middle) {
+                            true => *self.path * four,
+                            false => *self.path * four + bottom.into() + one.into()
+                        },
+                    }
+                }
+            ),
+            Option::None => {
+                // the node is leaf
+                return Option::None;
+            },
+        }
+    }
+}

--- a/src/quadtree/src/quadtree.cairo
+++ b/src/quadtree/src/quadtree.cairo
@@ -173,6 +173,58 @@ impl Felt252QuadtreeImpl<
         self.insert_at(value, path);
     }
 
+    fn insert_region(ref self: Felt252Quadtree<T, P, C>, value: T, region: Area<C>) {
+        // type interference hack
+        let one: u8 = 1;
+        let one: P = one.into();
+        let bottom = one + one;
+        let four: P = (bottom + bottom).into();
+
+        let mut to_visit = array![one];
+        let mut to_append = ArrayTrait::new();
+
+        loop {
+            // getting a smaller node
+            let path = match to_visit.pop_front() {
+                Option::Some(path) => path,
+                Option::None => {break;},
+            };
+            let (entry, val) = self.elements.entry(path.into());
+            let mut node = match match_nullable(val) {
+                FromNullableResult::Null => panic!("Node does not exist"),
+                FromNullableResult::NotNull(val) => val.unbox(),
+            };
+
+            if node.is_leaf.is_some() {
+                // if the node is a leaf, we add the value to the node or split it
+                // TODO: split the node
+                to_append.append(path);
+
+            } else
+            if region.contains(node.region.bottom_right()) && region.contains(node.region.top_left()) {
+                // if the region contains the node, we add it to the node
+                to_append.append(path);
+            } else {
+                // if the region does not contain the node, we check its children
+                let child_path = node.path * four;
+                to_visit.append(child_path);
+                to_visit.append(child_path + one);
+                to_visit.append(child_path + bottom);
+                to_visit.append(child_path + bottom + one);
+            }
+            
+            let val = nullable_from_box(BoxTrait::new(node));
+            self.elements = entry.finalize(val);
+        };
+
+        loop {
+            match to_visit.pop_front() {
+                Option::Some(path) => self.insert_at(value, path),
+                Option::None => {break;},
+            };
+        }
+    }
+
     fn split(ref self: Felt252Quadtree<T, P, C>, path: P, point: Point<C>) {
         // getting the node from the dictionary without cloning it
         let (entry, val) = self.elements.entry(path.into());

--- a/src/quadtree/src/quadtree.cairo
+++ b/src/quadtree/src/quadtree.cairo
@@ -107,8 +107,8 @@ impl Felt252QuadtreeImpl<
                 i += 1;
             };
 
+            // get the next node and return the current one to the dictionary
             path = node.child_at(@point);
-
             let val = nullable_from_box(BoxTrait::new(node));
             self.elements = entry.finalize(val);
         };
@@ -162,8 +162,8 @@ impl Felt252QuadtreeImpl<
                 FromNullableResult::NotNull(val) => val.unbox(),
             };
     
+            // get the next node and return the current one to the dictionary
             path = node.child_at(@point);
-
             let val = nullable_from_box(BoxTrait::new(node));
             self.elements = entry.finalize(val);
         };

--- a/src/quadtree/src/tests.cairo
+++ b/src/quadtree/src/tests.cairo
@@ -21,6 +21,21 @@ fn test_root() {
     assert_eq!(*tree.values(1).at(1), 2137);
 }
 
+
+#[test]
+fn test_insert_point() {
+    // Create a root region at (0, 0) with a width and height of 4
+    let root_region = AreaTrait::new(PointTrait::new(0, 0), 4, 4);
+    let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
+    tree.split(1, PointTrait::new(2, 2));
+
+    // Values can be inserted into the tree (at any place for now)
+    tree.insert_point(42, PointTrait::new(1, 1));
+
+    // and retrieved from it, in the same fashion
+    assert(tree.values(0b101).get(0).is_some(), 'nw does not exist');
+}
+
 #[test]
 fn test_split() {
     let root_region = AreaTrait::new(PointTrait::new(0, 0), 4, 4);

--- a/src/quadtree/src/tests.cairo
+++ b/src/quadtree/src/tests.cairo
@@ -13,8 +13,8 @@ fn test_root() {
     let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
 
     // Values can be inserted into the tree (at any place for now)
-    tree.insert(0, 42);
-    tree.insert(0, 2137);
+    tree.insert(42, 0, 0);
+    tree.insert(2137, 0, 0);
     // and retrieved from it, in the same fashion
     assert_eq!(*tree.values(0).at(0), 42);
     assert_eq!(*tree.values(0).at(1), 2137);

--- a/src/quadtree/src/tests.cairo
+++ b/src/quadtree/src/tests.cairo
@@ -83,28 +83,28 @@ fn test_rect_region() {
     assert_eq!(*tree.values(0b10111).get(0).unwrap().unbox(), 42);
 }
 
-// #[test]
-// fn test_query_regions() {
-//     // Create a root region at (0, 0) with a width and height of 4
-//     let root_region = AreaTrait::new(PointTrait::new(0, 0), 4, 4);
-//     let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
-//     tree.split(1, PointTrait::new(2, 2));
-//     tree.split(0b101, PointTrait::new(1, 1));
+#[test]
+fn test_query_regions() {
+    // Create a root region at (0, 0) with a width and height of 4
+    let root_region = AreaTrait::new(PointTrait::new(0, 0), 4, 4);
+    let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
+    tree.split(1, PointTrait::new(2, 2));
+    tree.split(0b101, PointTrait::new(1, 1));
 
-//     // tree.insert_region('whole', AreaTrait::new(PointTrait::new(0, 0), 4, 4));
-//     tree.insert_region('rect', AreaTrait::new(PointTrait::new(1, 0), 3, 2));
-//     // tree.insert_region('nw', AreaTrait::new(PointTrait::new(0, 0), 2, 2));
-//     // tree.insert_region('ne of nw', AreaTrait::new(PointTrait::new(1, 0), 1, 1));
-//     // tree.insert_region('sw of nw', AreaTrait::new(PointTrait::new(0, 1), 1, 1));
-//     // tree.insert_region('se of nw', AreaTrait::new(PointTrait::new(1, 1), 1, 1));
-//     // tree.insert_region('se', AreaTrait::new(PointTrait::new(2, 2), 2, 2));
+    tree.insert_region('whole', AreaTrait::new(PointTrait::new(0, 0), 4, 4));
+    tree.insert_region('rect', AreaTrait::new(PointTrait::new(1, 0), 3, 2));
+    tree.insert_region('nw', AreaTrait::new(PointTrait::new(0, 0), 2, 2));
+    tree.insert_region('ne of nw', AreaTrait::new(PointTrait::new(1, 0), 1, 1));
+    tree.insert_region('sw of nw', AreaTrait::new(PointTrait::new(0, 1), 1, 1));
+    tree.insert_region('se of nw', AreaTrait::new(PointTrait::new(1, 1), 1, 1));
+    tree.insert_region('se', AreaTrait::new(PointTrait::new(2, 2), 2, 2));
 
-//     let query_small = tree.query_regions(PointTrait::new(1, 1));
-//     // assert(*query_small.get(0).unwrap().unbox() == 'whole', 'no region whole');
-//     assert(*query_small.get(1).unwrap().unbox() == 'rect', 'no region rect');
-//     // assert(*query_small.get(2).unwrap().unbox() == 'nw', 'no region nw');
-//     // assert(*query_small.get(3).unwrap().unbox() == 'nw of nw', 'no region nw of nw');
-// }
+    let mut query_small = tree.query_regions(PointTrait::new(2, 1));
+    assert(query_small.pop_front().unwrap() == 'whole', 'no region whole');
+    assert(query_small.pop_front().unwrap() == 'nw', 'no region rect');
+    assert(query_small.pop_front().unwrap() == 'rect', 'no region rect');
+    assert(query_small.pop_front().unwrap() == 'ne of nw', 'no region ne of nw');
+}
 
 #[test]
 fn test_split() {

--- a/src/quadtree/src/tests.cairo
+++ b/src/quadtree/src/tests.cairo
@@ -1,7 +1,8 @@
+use core::box::BoxTrait;
 use core::option::OptionTrait;
 use core::array::ArrayTrait;
 use core::nullable::{nullable_from_box, match_nullable, FromNullableResult};
-use quadtree::quadtree::{QuadtreeTrait, Felt252QuadtreeNode, Felt252QuadtreeImpl};
+use quadtree::quadtree::{QuadtreeTrait, QuadtreeNode, Felt252QuadtreeImpl};
 use quadtree::area::{Area, AreaTrait};
 use quadtree::point::{Point, PointTrait};
 
@@ -82,6 +83,28 @@ fn test_rect_region() {
     assert_eq!(*tree.values(0b10111).get(0).unwrap().unbox(), 42);
 }
 
+// #[test]
+// fn test_query_regions() {
+//     // Create a root region at (0, 0) with a width and height of 4
+//     let root_region = AreaTrait::new(PointTrait::new(0, 0), 4, 4);
+//     let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
+//     tree.split(1, PointTrait::new(2, 2));
+//     tree.split(0b101, PointTrait::new(1, 1));
+
+//     // tree.insert_region('whole', AreaTrait::new(PointTrait::new(0, 0), 4, 4));
+//     tree.insert_region('rect', AreaTrait::new(PointTrait::new(1, 0), 3, 2));
+//     // tree.insert_region('nw', AreaTrait::new(PointTrait::new(0, 0), 2, 2));
+//     // tree.insert_region('ne of nw', AreaTrait::new(PointTrait::new(1, 0), 1, 1));
+//     // tree.insert_region('sw of nw', AreaTrait::new(PointTrait::new(0, 1), 1, 1));
+//     // tree.insert_region('se of nw', AreaTrait::new(PointTrait::new(1, 1), 1, 1));
+//     // tree.insert_region('se', AreaTrait::new(PointTrait::new(2, 2), 2, 2));
+
+//     let query_small = tree.query_regions(PointTrait::new(1, 1));
+//     // assert(*query_small.get(0).unwrap().unbox() == 'whole', 'no region whole');
+//     assert(*query_small.get(1).unwrap().unbox() == 'rect', 'no region rect');
+//     // assert(*query_small.get(2).unwrap().unbox() == 'nw', 'no region nw');
+//     // assert(*query_small.get(3).unwrap().unbox() == 'nw of nw', 'no region nw of nw');
+// }
 
 #[test]
 fn test_split() {

--- a/src/quadtree/src/tests.cairo
+++ b/src/quadtree/src/tests.cairo
@@ -14,8 +14,8 @@ fn test_root() {
     let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
 
     // Values can be inserted into the tree (at any place for now)
-    tree.insert(42, 1, 0);
-    tree.insert(2137, 1, 0);
+    tree.insert_at(42, 1);
+    tree.insert_at(2137, 1);
     // and retrieved from it, in the same fashion
     assert_eq!(*tree.values(1).at(0), 42);
     assert_eq!(*tree.values(1).at(1), 2137);

--- a/src/quadtree/src/tests.cairo
+++ b/src/quadtree/src/tests.cairo
@@ -1,3 +1,4 @@
+use core::option::OptionTrait;
 use core::array::ArrayTrait;
 use core::nullable::{nullable_from_box, match_nullable, FromNullableResult};
 use quadtree::quadtree::{QuadtreeTrait, Felt252QuadtreeNode, Felt252QuadtreeImpl};
@@ -13,12 +14,43 @@ fn test_root() {
     let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
 
     // Values can be inserted into the tree (at any place for now)
-    tree.insert(42, 0, 0);
-    tree.insert(2137, 0, 0);
+    tree.insert(42, 1, 0);
+    tree.insert(2137, 1, 0);
     // and retrieved from it, in the same fashion
-    assert_eq!(*tree.values(0).at(0), 42);
-    assert_eq!(*tree.values(0).at(1), 2137);
+    assert_eq!(*tree.values(1).at(0), 42);
+    assert_eq!(*tree.values(1).at(1), 2137);
 }
+
+#[test]
+fn test_split() {
+    let root_region = AreaTrait::new(PointTrait::new(0, 0), 4, 4);
+    let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
+    tree.split(1, PointTrait::new(1, 1));
+    tree.split(0b101, PointTrait::new(1, 1));
+
+    assert(tree.values(1).is_empty(), 'root does not exist');
+
+    assert(tree.values(0b100).is_empty(), 'ne does not exist');
+    assert(tree.values(0b101).is_empty(), 'nw does not exist');
+    assert(tree.values(0b101).is_empty(), 'se does not exist');
+    assert(tree.values(0b111).is_empty(), 'sw does not exist');
+
+    assert(tree.values(0b10100).is_empty(), 'ne of se does not exist');
+    assert(tree.values(0b10101).is_empty(), 'nw of se does not exist');
+    assert(tree.values(0b10110).is_empty(), 'se of se does not exist');
+    assert(tree.values(0b10111).is_empty(), 'sw of se does not exist');
+}
+
+#[test]
+#[should_panic]
+fn test_split_too_many() {
+    let root_region = AreaTrait::new(PointTrait::new(0, 0), 4, 4);
+    let mut tree = QuadtreeTrait::<felt252, felt252, u64>::new(root_region);
+    tree.split(1, PointTrait::new(1, 1));
+
+    assert(tree.values(8).is_empty(), 'out of bounds exists');
+}
+
 
 #[test]
 fn point_test() {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A (#2 of @neotheprogramist fork)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a `split` methods that creates children for a given node
- Added `insert_region` and `insert_point` methods that put a value in the right node of the quadtree
- Added `test_query_regions` method that visits all nodes on the path to a point and returns their values

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

### Implementation details

All the `QuadtreeNodes` are a part of a single `Dict`, with a path to each of them working as a key. 
In contrast to #3, the path is only a single value now.
The idea is described in greater detail [here](https://github.com/neotheprogramist/alexandria/blob/7adc070674026dd229671e7ccd191d3ed99e2966/src/quadtree/src/node.cairo#L13-L17)

### Future Work

This is the second stage of quadtree development. The next PR will focus on automatic spilling of nodes and value retrieval and deletion


